### PR TITLE
Related moves and combinations detail pop ups for move searches

### DIFF
--- a/src/old copies/combomovedialog.kv
+++ b/src/old copies/combomovedialog.kv
@@ -1,6 +1,7 @@
 <MoveDialogContent>:
     moves_popup: moves_popup
     size_hint_y: 4.5
+    md_bg_color: app.theme_cls.primary_dark
 
     ScrollView:
         MDList:

--- a/src/old copies/combomovedialog.py
+++ b/src/old copies/combomovedialog.py
@@ -1,0 +1,9 @@
+from kivymd.uix.dialog.dialog import MDDialog
+from kivymd.uix.boxlayout import MDBoxLayout
+
+
+class MoveDialogContent(MDBoxLayout):
+    pass
+
+
+

--- a/src/screens/combomovedialog.py
+++ b/src/screens/combomovedialog.py
@@ -1,9 +1,40 @@
 from kivymd.uix.dialog.dialog import MDDialog
 from kivymd.uix.boxlayout import MDBoxLayout
+from kivymd.uix.list import OneLineListItem, ThreeLineListItem
+from kivy.uix.label import Label
 
 
 class MoveDialogContent(MDBoxLayout):
     pass
 
 
+class MoveThreeLineList(ThreeLineListItem):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
+
+        self.longlabel = Label(text=self.text, size_hint_y=None,
+                              size = self.size, text_size=(None,None))
+        # self.add_widget(self.longlabel)
+        self.text = self.longlabel
+
+# class MoveThreeLineList(ThreeLineListItem):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#
+#         self.longlabel = Label(text=self.text, size_hint_y=None,
+#                               size = self.size,
+#                               height=self.texture_size[1],)
+#         self.add_widget(self.longlabel)
+
+
+class WrappingLabel(Label):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        text_size = (None, None),
+        size_hint_y = None,
+        size = self.size,
+        height = self.texture_size[1],
+        halign = "center",
+        valign = "middle"

--- a/src/screens/modulelist.py
+++ b/src/screens/modulelist.py
@@ -99,7 +99,7 @@ class ModuleOneLineListItem(OneLineListItem):
             no_results(req, error="Not found")
             return "no results"
         self.results_list = result
-        self.move_details = MoveDialogContent()
+        self.move_details = MoveDialogContent(md_bg_color="#c20404")
 
         for item in range(len(self.results_list)):
             name = result[item]["name"].capitalize()

--- a/src/screens/movelistclass.py
+++ b/src/screens/movelistclass.py
@@ -1,7 +1,13 @@
-from kivymd.uix.list import OneLineListItem
+from kivymd.uix.list import OneLineListItem, ThreeLineListItem
 from kivymd.uix.dialog.dialog import MDDialog
+from .combomovedialog import MoveDialogContent, MoveThreeLineList
 from kivymd.uix.button import MDFlatButton, MDRaisedButton, MDIconButton
 from kivymd.app import MDApp
+from kivy.metrics import dp, sp
+from kivy.network.urlrequest import UrlRequest
+from kivy.properties import ObjectProperty
+from kivy.uix.popup import Popup
+from kivy.uix.label import Label
 
 
 class MoveOneLineListItem(OneLineListItem):
@@ -38,6 +44,9 @@ class MoveOneLineListItem(OneLineListItem):
         dialog pop up, only IF the self.position is greater than 0
     """
 
+    move_details = ObjectProperty(None)
+    move_popup = ObjectProperty(None)
+
     def __init__(self, details, title, position, id, related, module, *args, **kwargs):
         """Constructs all necessary attributes for the move list object."""
         self.dialog = None
@@ -47,38 +56,48 @@ class MoveOneLineListItem(OneLineListItem):
         self.id = id
         self.related = related
         self.module = module
+        self.results_list = []
         super().__init__(*args, **kwargs)
 
     def on_release(self):
         """Creates MDDialog object with all of move details and buttons for navigating."""
-        buttons_list = [
-            MDIconButton(icon="arrow-left-bold-outline", pos_hint={"x": -2, "y": 0.1}, on_release=self.prev_item),
-            MDIconButton(icon="arrow-right-bold-outline", pos_hint={"x": -1.8, "y": 0.1}, on_release=self.next_item),
-            MDIconButton(icon="close", on_release=self.close_dialog, pos_hint={"x": 1, "y": 4.5})]
+        buttons_list = []
+        left = MDIconButton(icon="arrow-left-bold-outline", pos_hint={"y": 0.08}, on_release=self.prev_item)
+        right = MDIconButton(icon="arrow-right-bold-outline", pos_hint={"y": 0.08}, on_release=self.next_item)
+        exit = MDIconButton(icon="close", on_release=self.close_dialog, pos_hint={"x": 1, "y": 5.1})
+        buttons_list.append(MDIconButton(icon="close", opacity=0, disabled=True, pos_hint={"y": 0.12}))
         if self.related:
-            buttons_list.append(MDRaisedButton(text="Related", pos_hint={"x": -3, "y": 0.1}))
+            buttons_list.append(MDRaisedButton(text="Related", md_bg_color="green", pos_hint={"y": 0.12},
+                                               on_release=self.search_related_moves))
+        else:
+            buttons_list.append(MDRaisedButton(text="Related", opacity=0, disabled=True, pos_hint={"y": 0.12}))
+        buttons_list.append(MDRaisedButton(text="", opacity=0, disabled=True, pos_hint={"y": 0.12}))
+        buttons_list.append(left)
+        buttons_list.append(right)
+        buttons_list.append(MDIconButton(icon="close", opacity=0, disabled=True, pos_hint={"y": 0.12}))
         if self.module:
-            buttons_list.append(MDRaisedButton(text="Combinations", pos_hint={"x": -2.5, "y": 0.1}))
+            buttons_list.append(MDRaisedButton(text="Combinations", md_bg_color="#1f6dff", pos_hint={"y": 0.12},
+                                               on_release=self.search_combos_from_move))
+        else:
+            buttons_list.append(MDRaisedButton(text="Combinations", opacity=0, disabled=True, pos_hint={"y": 0.12}))
+        buttons_list.append(exit)
         self.dialog = MDDialog(title=self.title, text=self.details, buttons=buttons_list)
         self.dialog.open()
-
-    # def on_release(self):
-    #     """Creates MDDialog object with all of move details and buttons for navigating."""
-    #     self.dialog = MDDialog(title=self.title, text=self.details, buttons=[
-    #         MDIconButton(icon="arrow-left-bold-outline", pos_hint={"x": -2, "y": 0.1}, on_release=self.prev_item),
-    #         MDIconButton(icon="arrow-right-bold-outline", pos_hint={"x": -1.8, "y": 0.1}, on_release=self.next_item),
-    #         MDIconButton(icon="close", on_release=self.close_dialog, pos_hint={"x": 1, "y": 4.5})])
-    #     if self.related:
-    #         print("has related moves")
-    #         self.dialog.buttons = [MDRaisedButton(text="Move details", pos_hint={"x": 1, "y": 2})]
-    #     if self.module:
-    #         print("is in modules")
-    #     self.dialog.open()
 
     def close_dialog(self, instance):
         """Closes dialog pop up."""
         if self.dialog:
             self.dialog.dismiss()
+
+    def search_related_moves(self, instance):
+        """Makes a request to search moves in combo, on success calls show_moves method, on failure no_results."""
+        req = UrlRequest(f"http://127.0.0.1:5000/moves/related_moves/{self.id}", on_success=self.show_moves,
+                         on_error=no_results, on_failure=no_results)
+
+    def search_combos_from_move(self, instance):
+        """Makes a request to search moves in combo, on success calls show_moves method, on failure no_results."""
+        req = UrlRequest(f"http://127.0.0.1:5000/moves/module_combos/{self.id}", on_success=self.show_combos,
+                         on_error=no_results, on_failure=no_results)
 
     def next_item(self, instance):
         """Proceeds to open dialog of next item in list of objects if it exists."""
@@ -91,3 +110,68 @@ class MoveOneLineListItem(OneLineListItem):
         if self.position > 0:
             self.dialog.dismiss()
             MDApp.get_running_app().object_list[self.position - 1].on_release()
+
+    def show_moves(self, req, result):
+        """Takes results from url request, adds moves to a custom box widget in a loop, adds to an MDDialog & opens"""
+        if len(result) == 0:
+            no_results(req, error="Not found")
+            return "no results"
+        self.results_list = result
+        self.move_details = MoveDialogContent(md_bg_color="#0c6e01")
+
+        for item in range(len(self.results_list)):
+            name = result[item]["name"].capitalize()
+            code = result[item]["code"]
+            belt = result[item]["belt_colour"].capitalize()
+            plan = result[item]["lesson_plan"]
+            notes = result[item]["notes"]
+
+            if notes is not None:
+                notes_text = f"Notes: {notes}"
+            else:
+                notes_text = ""
+            details = f"Move ID: {code} | Belt: {belt} | Lesson plan: {plan}"
+            new_list = ThreeLineListItem(text=name, secondary_text=details, tertiary_text=notes_text)
+            self.move_details.moves_popup.add_widget(new_list)
+
+        self.move_popup = MDDialog()
+        self.move_popup.add_widget(self.move_details)
+        self.move_popup.open()
+
+    def show_combos(self, req, result):
+        """Takes results from url request, adds moves to a custom box widget in a loop, adds to an MDDialog & opens"""
+        if len(result) == 0:
+            no_results(req, error="Not found")
+            return "no results"
+        self.results_list = result
+        self.move_details = MoveDialogContent(md_bg_color="#0228e3")
+
+        for item in range(len(self.results_list)):
+            id = result[item]["id"]
+            name = result[item]["name"]
+            code = result[item]["code"][0:2]
+            kick = result[item]["is_kick"]
+            jump = result[item]["is_jump"]
+            notes = result[item]["notes"]
+
+            if notes is not None:
+                notes_text = f"Notes: {notes}"
+            else:
+                notes_text = ""
+            if code == "M1":
+                module = "Module 1"
+            else:
+                module = "Module 2"
+            details = f"{module} | {id} | Kick: {kick} | Jump: {jump}"
+            new_list = ThreeLineListItem(text=name, secondary_text=details, tertiary_text=notes_text)
+            self.move_details.moves_popup.add_widget(new_list)
+
+        self.move_popup = MDDialog()
+        self.move_popup.add_widget(self.move_details)
+        self.move_popup.open()
+
+
+def no_results(req, error):
+    """Opens pop up window if no results found."""
+    pop = Popup(title="Not found", content=Label(text="No results found"), size_hint=(None, None), size=(300, 200))
+    pop.open()


### PR DESCRIPTION
MoveDialogContent also used for related moves and combinations of move search pop ups. Changed the colour from style file to getting added when class created so can use different colours. Slight roundabout way of doing it but buttons appended in a certain order and blanks used to control the positioning of the buttons (left, right, related if present, combos if present, and close).